### PR TITLE
Use maven-resolver-provider:3.5.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile 'org.eclipse.aether:aether-api:1.1.0'
-    compile 'org.eclipse.aether:aether-spi:1.1.0'
-    compile 'org.eclipse.aether:aether-util:1.1.0'
-    compile 'org.eclipse.aether:aether-impl:1.1.0'
-    compile 'org.apache.maven:maven-aether-provider:3.3.9'
-    compile 'org.apache.maven:maven-artifact:3.3.9'
+    compile 'org.apache.maven:maven-resolver-provider:3.5.4'
+    compile 'org.apache.maven:maven-artifact:3.5.4'
 }

--- a/src/main/java/SearchMavenLocal.java
+++ b/src/main/java/SearchMavenLocal.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -39,7 +40,8 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 
 public class SearchMavenLocal {
-    public static void main(final String[] args) {
+    public static void main(final String[] args) throws Exception {
+        final MavenArtifactFinder finder = MavenArtifactFinder.create(Paths.get("/tmp"));
     }
 }
 


### PR DESCRIPTION
Wow, maven-resolver-provider does not need packages of `org.eclipse.aether`!

```
./gradlew dependencies

> Task :dependencies

------------------------------------------------------------
Root project
------------------------------------------------------------

annotationProcessor - Annotation processors and their dependencies for source set 'main'.
No dependencies

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts.
No dependencies

compile - Dependencies for source set 'main' (deprecated, use 'implementation' instead).
+--- org.apache.maven:maven-resolver-provider:3.5.4
|    +--- org.apache.maven:maven-model:3.5.4
|    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    \--- org.apache.commons:commons-lang3:3.5
|    +--- org.apache.maven:maven-model-builder:3.5.4
|    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    +--- org.codehaus.plexus:plexus-interpolation:1.24
|    |    +--- org.codehaus.plexus:plexus-component-annotations:1.7.1
|    |    +--- org.apache.maven:maven-model:3.5.4 (*)
|    |    +--- org.apache.maven:maven-artifact:3.5.4
|    |    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    |    \--- org.apache.commons:commons-lang3:3.5
|    |    +--- org.apache.maven:maven-builder-support:3.5.4
|    |    |    \--- org.apache.commons:commons-lang3:3.5
|    |    +--- com.google.guava:guava:20.0
|    |    \--- org.apache.commons:commons-lang3:3.5
|    +--- org.apache.maven:maven-repository-metadata:3.5.4
|    |    \--- org.codehaus.plexus:plexus-utils:3.1.0
|    +--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-spi:1.1.1
|    |    \--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-util:1.1.1
|    |    \--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-impl:1.1.1
|    |    +--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    |    +--- org.apache.maven.resolver:maven-resolver-spi:1.1.1 (*)
|    |    \--- org.apache.maven.resolver:maven-resolver-util:1.1.1 (*)
|    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    +--- javax.inject:javax.inject:1
|    \--- org.apache.commons:commons-lang3:3.5
\--- org.apache.maven:maven-artifact:3.5.4 (*)

.........

runtime - Runtime dependencies for source set 'main' (deprecated, use 'runtimeOnly' instead).
+--- org.apache.maven:maven-resolver-provider:3.5.4
|    +--- org.apache.maven:maven-model:3.5.4
|    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    \--- org.apache.commons:commons-lang3:3.5
|    +--- org.apache.maven:maven-model-builder:3.5.4
|    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    +--- org.codehaus.plexus:plexus-interpolation:1.24
|    |    +--- org.codehaus.plexus:plexus-component-annotations:1.7.1
|    |    +--- org.apache.maven:maven-model:3.5.4 (*)
|    |    +--- org.apache.maven:maven-artifact:3.5.4
|    |    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    |    \--- org.apache.commons:commons-lang3:3.5
|    |    +--- org.apache.maven:maven-builder-support:3.5.4
|    |    |    \--- org.apache.commons:commons-lang3:3.5
|    |    +--- com.google.guava:guava:20.0
|    |    \--- org.apache.commons:commons-lang3:3.5
|    +--- org.apache.maven:maven-repository-metadata:3.5.4
|    |    \--- org.codehaus.plexus:plexus-utils:3.1.0
|    +--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-spi:1.1.1
|    |    \--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-util:1.1.1
|    |    \--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-impl:1.1.1
|    |    +--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    |    +--- org.apache.maven.resolver:maven-resolver-spi:1.1.1 (*)
|    |    \--- org.apache.maven.resolver:maven-resolver-util:1.1.1 (*)
|    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    +--- javax.inject:javax.inject:1
|    \--- org.apache.commons:commons-lang3:3.5
\--- org.apache.maven:maven-artifact:3.5.4 (*)

.........

testCompile - Dependencies for source set 'test' (deprecated, use 'testImplementation' instead).
+--- org.apache.maven:maven-resolver-provider:3.5.4
|    +--- org.apache.maven:maven-model:3.5.4
|    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    \--- org.apache.commons:commons-lang3:3.5
|    +--- org.apache.maven:maven-model-builder:3.5.4
|    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    +--- org.codehaus.plexus:plexus-interpolation:1.24
|    |    +--- org.codehaus.plexus:plexus-component-annotations:1.7.1
|    |    +--- org.apache.maven:maven-model:3.5.4 (*)
|    |    +--- org.apache.maven:maven-artifact:3.5.4
|    |    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    |    \--- org.apache.commons:commons-lang3:3.5
|    |    +--- org.apache.maven:maven-builder-support:3.5.4
|    |    |    \--- org.apache.commons:commons-lang3:3.5
|    |    +--- com.google.guava:guava:20.0
|    |    \--- org.apache.commons:commons-lang3:3.5
|    +--- org.apache.maven:maven-repository-metadata:3.5.4
|    |    \--- org.codehaus.plexus:plexus-utils:3.1.0
|    +--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-spi:1.1.1
|    |    \--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-util:1.1.1
|    |    \--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-impl:1.1.1
|    |    +--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    |    +--- org.apache.maven.resolver:maven-resolver-spi:1.1.1 (*)
|    |    \--- org.apache.maven.resolver:maven-resolver-util:1.1.1 (*)
|    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    +--- javax.inject:javax.inject:1
|    \--- org.apache.commons:commons-lang3:3.5
\--- org.apache.maven:maven-artifact:3.5.4 (*)

.........

testRuntime - Runtime dependencies for source set 'test' (deprecated, use 'testRuntimeOnly' instead).
+--- org.apache.maven:maven-resolver-provider:3.5.4
|    +--- org.apache.maven:maven-model:3.5.4
|    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    \--- org.apache.commons:commons-lang3:3.5
|    +--- org.apache.maven:maven-model-builder:3.5.4
|    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    +--- org.codehaus.plexus:plexus-interpolation:1.24
|    |    +--- org.codehaus.plexus:plexus-component-annotations:1.7.1
|    |    +--- org.apache.maven:maven-model:3.5.4 (*)
|    |    +--- org.apache.maven:maven-artifact:3.5.4
|    |    |    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    |    |    \--- org.apache.commons:commons-lang3:3.5
|    |    +--- org.apache.maven:maven-builder-support:3.5.4
|    |    |    \--- org.apache.commons:commons-lang3:3.5
|    |    +--- com.google.guava:guava:20.0
|    |    \--- org.apache.commons:commons-lang3:3.5
|    +--- org.apache.maven:maven-repository-metadata:3.5.4
|    |    \--- org.codehaus.plexus:plexus-utils:3.1.0
|    +--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-spi:1.1.1
|    |    \--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-util:1.1.1
|    |    \--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    +--- org.apache.maven.resolver:maven-resolver-impl:1.1.1
|    |    +--- org.apache.maven.resolver:maven-resolver-api:1.1.1
|    |    +--- org.apache.maven.resolver:maven-resolver-spi:1.1.1 (*)
|    |    \--- org.apache.maven.resolver:maven-resolver-util:1.1.1 (*)
|    +--- org.codehaus.plexus:plexus-utils:3.1.0
|    +--- javax.inject:javax.inject:1
|    \--- org.apache.commons:commons-lang3:3.5
\--- org.apache.maven:maven-artifact:3.5.4 (*)

.........

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 0s
1 actionable task: 1 executed
```